### PR TITLE
replaced copy with vscode.env.clipboard

### DIFF
--- a/src/copy-with-line-numbers.ts
+++ b/src/copy-with-line-numbers.ts
@@ -64,10 +64,11 @@ function copyWithLineNumbers(option?) {
     }
   })
 
-  copy(str, () => {
-    const showSuccessMessage = vscode.workspace.getConfiguration('copyWithLineNumbers').get('showSuccessMessage')
-    if (showSuccessMessage) vscode.window.showInformationMessage('Copied!')
-  })
+  vscode.env.clipboard.writeText(str).then(() => {
+	const showSuccessMessage = vscode.workspace.getConfiguration('copyWithLineNumbers').get('showSuccessMessage');
+	if (showSuccessMessage)
+		vscode.window.showInformationMessage('Copied!');
+	})
 }
 
 export const commands = {


### PR DESCRIPTION
Based on issue #6 I have replaced `copy` with `vscode.env.clipboard.writeText` :
```js
File: src\copy-with-line-numbers.ts
66: 
67: ➡  vscode.env.clipboard.writeText(str).then(() => {
68: 	const showSuccessMessage = vscode.workspace.getConfiguration('copyWithLineNumbers').get('showSuccessMessage');
69: 	if (showSuccessMessage)
70: 		vscode.window.showInformationMessage('Copied!');
71: 	})
```
The extension now works also with remote connections